### PR TITLE
Fix GET memberships to paginate correctly

### DIFF
--- a/database/migration/2020-11-29/migration.sql
+++ b/database/migration/2020-11-29/migration.sql
@@ -2,6 +2,7 @@ CREATE DATABASE kkm_registry;
 
 create extension if not exists "uuid-ossp";
 
+-- test users: test+n@test.com/PassWord123!
 -- user_role: user, admin
 CREATE TABLE logins(
   user_id uuid PRIMARY KEY DEFAULT
@@ -9,7 +10,7 @@ CREATE TABLE logins(
   user_email VARCHAR(255) UNIQUE NOT NULL,
   user_password VARCHAR(255) NOT NULL,
   user_role VARCHAR(255) DEFAULT 'user' NOT NULL,
-  user_last_login TIMESTAMP
+  user_last_login TIMESTAMPTZ DEFAULT now()
 );
 
 CREATE UNIQUE INDEX idx_logins_on_email_asc ON logins USING btree (user_email ASC);
@@ -21,15 +22,15 @@ CREATE TABLE users(
   user_home_address VARCHAR(255)
 );
 
--- status: request, approve, reject
+-- status: requested, approved, rejected
 CREATE TABLE memberships(
   user_id uuid PRIMARY KEY REFERENCES logins,
   user_membership_no VARCHAR(255),
-  status VARCHAR(255) DEFAULT 'request' NOT NULL,
-  requested_on TIMESTAMP NOT NULL,
+  status VARCHAR(255) DEFAULT 'requested' NOT NULL,
+  requested_on TIMESTAMPTZ DEFAULT now(),
   responded_by uuid REFERENCES logins,
-  responded_on TIMESTAMP,
+  responded_on TIMESTAMPTZ,
   reason VARCHAR(255)
 )
 
--- test users: test+n@test.com/PassWord123!
+CREATE UNIQUE INDEX idx_memberships_on_requested_on_asc ON memberships USING btree (requested_on ASC);

--- a/routes/swaggerDef.js
+++ b/routes/swaggerDef.js
@@ -32,7 +32,6 @@
 
 /**
  * @typedef Membership
- * @property {string} membership_id
  * @property {string} user_id
  * @property {string} user_email
  * @property {string} user_name


### PR DESCRIPTION
https://trello.com/c/AOE3ljV4/32-admin-can-view-kkm-membership-requests

- Update timestamp fields to timestamptz and default to now()
- Update default status in memberships table to "requested"
- Remove new Date().toISOString() as the fields are now defaulted to now()
- Add index to `requested_on` column in `memberships`
- Fix GET membership to correctly compare timestamptz fields
- Remove membership_id from SQL queries in GET membership and in swagger